### PR TITLE
change middleware to factory; change url base

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ current url in the store.
 
 ## Example
 
-Example initialization - add the router.middleware to redux
+Example initialization - add the router middleware to redux
 ```
 var riot = require('riot')
 var redux = require('redux')
@@ -41,7 +41,7 @@ var router = require('riot-redux-router-immutable')
 var rootReducer = require('./app/reducer')
 
 var createStoreWithMiddleware = redux.compose(
-  redux.applyMiddleware(router.middleware),
+  redux.applyMiddleware(router.middleware.factory()),
   // your other redux middleware here...
 )(redux.createStore)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-redux-router-immutable",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ImmutableJS + RiotJS Router + Redux Middleware",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Change middleware to factory so application can pass in a default
url base more easily.

Change url base default from '/' to the riot router default ('#') and
fix logic that incorrectly mixed the url base and the url separator.
